### PR TITLE
Allow fetching deps from CUE Central Registry

### DIFF
--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -81,6 +81,9 @@ on:
       client-secret:
         description: Client Secret used for robotic access when using external authentication provider.
         required: false
+      cue-token:
+        description: Token for CUE's Central Registry.
+        required: false
 
 jobs:
   dac:
@@ -103,7 +106,7 @@ jobs:
   
       - name: Login to CUE's Central Registry to allow retrieving deps
         if: ${{ !inputs.skip-cue-login }}
-        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
+        run: cue login --token=${{ secrets.cue-token }}
 
       - name: Build the dashboards
         uses: perses/cli-actions/actions/build_dac@main

--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -94,6 +94,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
+          cue_version: "v0.12.0"
 
       - name: Install percli
         uses: perses/cli-actions/actions/install_percli@main

--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -37,6 +37,10 @@ on:
         description: Skip the dashboard deployment stage if provided.
         type: boolean
         required: false
+      skip-cue-login:
+        description: Skip the `cue login` stage. Useful if you e.g you are only using Go to code dashboards.
+        type: boolean
+        required: false
       # auth:
       provider:
         description: External authentication provider identifier. (slug_id)
@@ -95,6 +99,10 @@ jobs:
         uses: perses/cli-actions/actions/install_percli@main
         with:
           cli_version: ${{ inputs.cli_version }}
+  
+      - name: Login to CUE's Central Registry to allow retrieving deps
+        if: ${{ !inputs.skip-cue-login }}
+        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
 
       - name: Build the dashboards
         uses: perses/cli-actions/actions/build_dac@main

--- a/.github/workflows/test_build_dac.yaml
+++ b/.github/workflows/test_build_dac.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: v0.51.0-beta.0 # TODO change to stable release when possible
+          cli_version: v0.51.0-beta.1 # TODO change to stable release when possible
 
       - name: Install cue binary
         uses: perses/github-actions/actions/setup_environment@main

--- a/.github/workflows/test_build_dac.yaml
+++ b/.github/workflows/test_build_dac.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
+          cue_version: "v0.12.0"
   
       - name: Login to CUE's Central Registry to allow retrieving deps
         if: ${{ !inputs.skip-cue-login }}

--- a/.github/workflows/test_build_dac.yaml
+++ b/.github/workflows/test_build_dac.yaml
@@ -20,13 +20,17 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: latest
+          cli_version: v0.51.0-beta.0 # TODO change to stable release when possible
 
       - name: Install cue binary
         uses: perses/github-actions/actions/setup_environment@main
         with:
           enable_go: true
           enable_cue: true
+  
+      - name: Login to CUE's Central Registry to allow retrieving deps
+        if: ${{ !inputs.skip-cue-login }}
+        run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
 
       - name: Test build DaC with directory
         uses: ./actions/build_dac

--- a/.github/workflows/test_dac.yaml
+++ b/.github/workflows/test_dac.yaml
@@ -22,3 +22,4 @@ jobs:
     secrets:
       username: ${{ secrets.TEST_USERNAME }}
       password: ${{ secrets.TEST_PASSWORD }}
+      cue-token: ${{ secrets.CUE_REG_TOKEN }}

--- a/.github/workflows/test_dac.yaml
+++ b/.github/workflows/test_dac.yaml
@@ -18,7 +18,7 @@ jobs:
       url: https://demo.perses.dev
       directory: ./testdata/dac_folder
       server-validation: true
-      cli_version: v0.51.0-beta.0 # TODO change to stable release when possible
+      cli_version: v0.51.0-beta.1 # TODO change to stable release when possible
     secrets:
       username: ${{ secrets.TEST_USERNAME }}
       password: ${{ secrets.TEST_PASSWORD }}

--- a/.github/workflows/test_dac.yaml
+++ b/.github/workflows/test_dac.yaml
@@ -18,7 +18,7 @@ jobs:
       url: https://demo.perses.dev
       directory: ./testdata/dac_folder
       server-validation: true
-      cli_version: v0.50.0-rc.0
+      cli_version: v0.51.0-beta.0 # TODO change to stable release when possible
     secrets:
       username: ${{ secrets.TEST_USERNAME }}
       password: ${{ secrets.TEST_PASSWORD }}

--- a/.github/workflows/test_validate_resources.yaml
+++ b/.github/workflows/test_validate_resources.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           enable_go: true
           enable_cue: true
+          cue_version: "v0.12.0"
 
       - name: Test resources validation
         uses: ./actions/validate_resources

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ jobs:
       url: https://demo.perses.dev
       directory: ./dac
       server-validation: true
+      skip-cue-login: true # when working with Go SDK only
     secrets:
       username: ${{ secrets.USR }}
       password: ${{ secrets.PWD }}

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,0 +1,9 @@
+module: "github.com/perses/cli-actions"
+language: {
+	version: "v0.12.0"
+}
+deps: {
+	"github.com/perses/perses/cue@v0": {
+		v: "v0.0.2-test"
+	}
+}

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -4,6 +4,6 @@ language: {
 }
 deps: {
 	"github.com/perses/perses/cue@v0": {
-		v: "v0.0.2-test"
+		v: "v0.51.0-preview"
 	}
 }

--- a/testdata/dac_file.cue
+++ b/testdata/dac_file.cue
@@ -1,12 +1,5 @@
 package dac
 
-kind: "Dashboard"
-metadata: {
-    name: "empty_dashboard",
-    project: "perses-cli-actions"
-},
-spec: {
-    display: name: "Empty Dashboard"
-    duration: "1h",
-    refreshInterval: "0s"
-}
+import "github.com/perses/perses/cue/dac-utils/dashboard@v0"
+
+dashboard & { #name: "empty_dashboard", #project: "perses-cli-actions" }

--- a/testdata/dac_folder/file.cue
+++ b/testdata/dac_folder/file.cue
@@ -1,12 +1,5 @@
 package dac
 
-kind: "Dashboard"
-metadata: {
-    name: "empty_dashboard",
-    project: "perses-cli-actions"
-},
-spec: {
-    display: name: "Empty Dashboard"
-    duration: "1h",
-    refreshInterval: "0s"
-}
+import "github.com/perses/perses/cue/dac-utils/dashboard@v0"
+
+dashboard & { #name: "empty_dashboard", #project: "perses-cli-actions" }


### PR DESCRIPTION
Make `dac` workflow compatible with CUE new modules by adding a `cue login` stage to be able to fetch deps from the central registry