### PR TITLE
[BREAKINGCHANGE] rename `cli_version` to `cli-version`

### DIFF
--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -19,7 +19,7 @@ on:
         description: If present, the project scope for this CLI request.
         type: string
         required: false
-      cli_version:
+      cli-version:
         description: Version of percli to install
         type: string
         default: latest
@@ -102,7 +102,7 @@ jobs:
       - name: Install percli
         uses: perses/cli-actions/actions/install_percli@main
         with:
-          cli_version: ${{ inputs.cli_version }}
+          cli-version: ${{ inputs.cli-version }}
   
       - name: Login to CUE's Central Registry to allow retrieving deps
         if: ${{ !inputs.skip-cue-login }}

--- a/.github/workflows/test_apply_resources.yaml
+++ b/.github/workflows/test_apply_resources.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: "latest"
+          cli-version: "latest"
 
       - name: Login to the API server
         uses: ./actions/login

--- a/.github/workflows/test_build_dac.yaml
+++ b/.github/workflows/test_build_dac.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: v0.51.0-beta.1 # TODO change to stable release when possible
+          cli-version: v0.51.0-beta.1 # TODO change to stable release when possible
 
       - name: Install cue binary
         uses: perses/github-actions/actions/setup_environment@main

--- a/.github/workflows/test_dac.yaml
+++ b/.github/workflows/test_dac.yaml
@@ -18,7 +18,7 @@ jobs:
       url: https://demo.perses.dev
       directory: ./testdata/dac_folder
       server-validation: true
-      cli_version: v0.51.0-beta.1 # TODO change to stable release when possible
+      cli-version: v0.51.0-beta.1 # TODO change to stable release when possible
     secrets:
       username: ${{ secrets.TEST_USERNAME }}
       password: ${{ secrets.TEST_PASSWORD }}

--- a/.github/workflows/test_diff_dashboards.yaml
+++ b/.github/workflows/test_diff_dashboards.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: "latest"
+          cli-version: "latest"
 
       - name: Login to the API server
         uses: ./actions/login

--- a/.github/workflows/test_install_percli.yaml
+++ b/.github/workflows/test_install_percli.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: "latest"
+          cli-version: "latest"

--- a/.github/workflows/test_preview_dashboards.yaml
+++ b/.github/workflows/test_preview_dashboards.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: "latest"
+          cli-version: "latest"
 
       - name: Login to the API server
         uses: ./actions/login

--- a/.github/workflows/test_validate_resources.yaml
+++ b/.github/workflows/test_validate_resources.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli_version: latest
+          cli-version: latest
 
       - name: Install cue binary
         uses: perses/github-actions/actions/setup_environment@main

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ steps:
   - name: Install percli
     uses: perses/cli-actions/actions/install_percli@v0.1.0
     with:
-      cli_version: "latest"
+      cli-version: "latest"
 ```
 
 ### [`login`](./actions/login/action.yaml)

--- a/actions/install_percli/action.yaml
+++ b/actions/install_percli/action.yaml
@@ -1,7 +1,7 @@
 name: Install percli
 description: Install the Perses CLI
 inputs:
-  cli_version:
+  cli-version:
     description: Version of percli to install
     default: latest
 runs:
@@ -9,8 +9,8 @@ runs:
   steps:
     - name: Install percli from docker image
       run: |
-        docker pull persesdev/perses:${{ inputs.cli_version }}
-        docker create --name tempcontainer persesdev/perses:${{ inputs.cli_version }}
+        docker pull persesdev/perses:${{ inputs.cli-version }}
+        docker create --name tempcontainer persesdev/perses:${{ inputs.cli-version }}
         docker cp tempcontainer:/bin/percli /usr/local/bin/percli
         docker rm tempcontainer
       shell: bash


### PR DESCRIPTION
Rename `cli_version` to `cli-version` for consistency in naming convention