### PR TITLE
Add current dashboard link to the previews comment

### DIFF
--- a/.github/workflows/test_apply_resources.yaml
+++ b/.github/workflows/test_apply_resources.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli-version: "latest"
+          cli-version: latest
 
       - name: Login to the API server
         uses: ./actions/login

--- a/.github/workflows/test_diff_dashboards.yaml
+++ b/.github/workflows/test_diff_dashboards.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli-version: "latest"
+          cli-version: latest
 
       - name: Login to the API server
         uses: ./actions/login

--- a/.github/workflows/test_install_percli.yaml
+++ b/.github/workflows/test_install_percli.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli-version: "latest"
+          cli-version: latest

--- a/.github/workflows/test_preview_dashboards.yaml
+++ b/.github/workflows/test_preview_dashboards.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install percli
         uses: ./actions/install_percli
         with:
-          cli-version: "latest"
+          cli-version: v0.51.0-beta.1 # TODO change to stable release when possible
 
       - name: Login to the API server
         uses: ./actions/login

--- a/actions/preview_dashboards/action.yaml
+++ b/actions/preview_dashboards/action.yaml
@@ -40,8 +40,20 @@ runs:
         script: |
           const fs = require('fs');
           const data = JSON.parse(fs.readFileSync('preview_output.json', 'utf8'));
-          const previewLinks = data.map(item => `- [${item.project}/${item.dashboard}](${item.preview})`).join('\n');
-          const commentBody = `### Dashboard previews\nThe following ephemeral dashboards have been deployed:\n\n${previewLinks}`;
+
+          // Build table header
+          let table = `| Project | Dashboard | Status | Preview | Current |\n`;
+          table +=    `|---------|-----------|--------|---------|---------|\n`;
+
+          // Build table rows
+          for (const item of data) {
+            const status = item.current == '' ? 'NEW' : 'UPDATED';
+            const currentLink = item.current == '' ? 'N/A' : `[Current](${item.current})` ;
+            table += `| ${item.project} | ${item.dashboard} | ${status} | [Preview](${item.preview}) | ${currentLink} |\n`;
+          }
+
+          const commentBody = `### Dashboard previews\n\n${table}`;
+
           github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
Leverage https://github.com/perses/perses/pull/2505.

Current output is like:

> ### Dashboard previews
> The following ephemeral dashboards have been deployed:
> 
> - [perses-cli-actions/empty_dashboard](link)
> - [perses-cli-actions/brand_new_dashboard](link)

With the change it's like:

> ### Dashboard previews
> 
> | Project | Dashboard | Status | Preview | Current |
> |---------|-----------|--------|---------|---------|
> | perses-cli-actions | empty_dashboard | UPDATED | [Preview](link) | [Current](link) |
> | perses-cli-actions | brand_new_dashboard | NEW | [Preview](link) | N/A |