### PR TITLE
fix action refs in dac workflow

### DIFF
--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -20,7 +20,7 @@ on:
         type: string
         required: false
       cli-version:
-        description: Version of percli to install
+        description: Version of percli to install. /!\ For this version of the workflow, the percli version should be at least v0.51.0-beta.1 or higher
         type: string
         default: latest
         required: false
@@ -93,14 +93,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install necessary tools
-        uses: perses/github-actions/actions/setup_environment@main
+        uses: perses/github-actions/actions/setup_environment@v0.9.0
         with:
           enable_go: true
           enable_cue: true
           cue_version: "v0.12.0"
 
       - name: Install percli
-        uses: perses/cli-actions/actions/install_percli@main
+        uses: ./actions/install_percli
         with:
           cli-version: ${{ inputs.cli-version }}
   
@@ -109,13 +109,13 @@ jobs:
         run: cue login --token=${{ secrets.cue-token }}
 
       - name: Build the dashboards
-        uses: perses/cli-actions/actions/build_dac@main
+        uses: ./actions/build_dac
         with:
           directory: ${{ inputs.directory }}
           file: ${{ inputs.file }}
 
       - name: Login to the API server
-        uses: perses/cli-actions/actions/login@main
+        uses: ./actions/login
         with:
           url: ${{ inputs.url }}
           username: ${{ secrets.username }}
@@ -127,14 +127,14 @@ jobs:
           insecure-skip-tls-verify: ${{ inputs.insecure-skip-tls-verify }}
 
       - name: Validate the dashboards
-        uses: perses/cli-actions/actions/validate_resources@main
+        uses: ./actions/validate_resources
         with:
           directory: ./built
           online: ${{ inputs.server-validation }}
 
       - name: Preview the dashboards
         if: ${{ github.event_name == 'pull_request' && !inputs.skip-preview }}
-        uses: perses/cli-actions/actions/preview_dashboards@main
+        uses: ./actions/preview_dashboards
         with:
           directory: ./built
           project: ${{ inputs.project }}
@@ -143,14 +143,14 @@ jobs:
 
       - name: Generate dashboards diffs
         if: ${{ github.event_name == 'pull_request' && !inputs.skip-diff }}
-        uses: perses/cli-actions/actions/diff_dashboards@main
+        uses: ./actions/diff_dashboards
         with:
           directory: ./built
           project: ${{ inputs.project }}
 
       - name: Deploy the dashboards
         if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && !inputs.skip-deploy }}
-        uses: perses/cli-actions/actions/apply_resources@main
+        uses: ./actions/apply_resources
         with:
           directory: ./built
           project: ${{ inputs.project }}


### PR DESCRIPTION
the `dac` workflow should actually use the "local" version of the actions and not `@main` or any other version, otherwise it is misleading with the version of the workflow itself when calling it + especially with @main it can lead to weird setups were calling a very old version of the workflow would actually then call the latest versions of the actions.. this PR fixes that.