### PR TITLE
fix action refs in dac workflow (again)

### DIFF
--- a/.github/workflows/dac.yaml
+++ b/.github/workflows/dac.yaml
@@ -99,8 +99,22 @@ jobs:
           enable_cue: true
           cue_version: "v0.12.0"
 
+      - name: Retrieve workflow version
+        id: workflow-version
+        uses: canonical/get-workflow-version-action@v1
+        with:
+          repository-name: perses/cli-actions
+          file-name: dac.yaml
+
+      - name: Check out actions using workflow version
+        uses: actions/checkout@v4
+        with:
+          repository: perses/cli-actions
+          ref: ${{ steps.workflow-version.outputs.sha }}
+          path: perses-cli-actions
+
       - name: Install percli
-        uses: ./actions/install_percli
+        uses: ./perses-cli-actions/actions/install_percli
         with:
           cli-version: ${{ inputs.cli-version }}
   
@@ -109,13 +123,13 @@ jobs:
         run: cue login --token=${{ secrets.cue-token }}
 
       - name: Build the dashboards
-        uses: ./actions/build_dac
+        uses: ./perses-cli-actions/actions/build_dac
         with:
           directory: ${{ inputs.directory }}
           file: ${{ inputs.file }}
 
       - name: Login to the API server
-        uses: ./actions/login
+        uses: ./perses-cli-actions/actions/login
         with:
           url: ${{ inputs.url }}
           username: ${{ secrets.username }}
@@ -127,14 +141,14 @@ jobs:
           insecure-skip-tls-verify: ${{ inputs.insecure-skip-tls-verify }}
 
       - name: Validate the dashboards
-        uses: ./actions/validate_resources
+        uses: ./perses-cli-actions/actions/validate_resources
         with:
           directory: ./built
           online: ${{ inputs.server-validation }}
 
       - name: Preview the dashboards
         if: ${{ github.event_name == 'pull_request' && !inputs.skip-preview }}
-        uses: ./actions/preview_dashboards
+        uses: ./perses-cli-actions/actions/preview_dashboards
         with:
           directory: ./built
           project: ${{ inputs.project }}
@@ -143,14 +157,14 @@ jobs:
 
       - name: Generate dashboards diffs
         if: ${{ github.event_name == 'pull_request' && !inputs.skip-diff }}
-        uses: ./actions/diff_dashboards
+        uses: ./perses-cli-actions/actions/diff_dashboards
         with:
           directory: ./built
           project: ${{ inputs.project }}
 
       - name: Deploy the dashboards
         if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && !inputs.skip-deploy }}
-        uses: ./actions/apply_resources
+        uses: ./perses-cli-actions/actions/apply_resources
         with:
           directory: ./built
           project: ${{ inputs.project }}


### PR DESCRIPTION
Additional fix following #5 as the latter doesnt work as expected: I forgot that the local refs can't be resolved when calling the workflow from an external repository..
What I want to achieve here is made tricky because there's no easy way for a workflow to "know" with which reference it was called in order to pass it down to the actions it calls.
Quite some people raised this already via https://github.com/actions/toolkit/issues/1264.

EDIT my latest try using https://github.com/canonical/get-workflow-version-action seems to work, I'll merge & try with an external repo again, let's see..

EDIT2 works as expected!
